### PR TITLE
Fix Dockerfile ENV format to modern standard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,9 @@ RUN apt-get -y upgrade && \
     apt-get -y autoremove && \
     apt-get clean
 
-ENV HOME /app
-ENV SHELL bash
-ENV WORKON_HOME /app
+ENV HOME=/app
+ENV SHELL=bash
+ENV WORKON_HOME=/app
 WORKDIR /app
 
 COPY requirements.txt /app/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,7 @@ dateutils==0.6.12
 shortuuid==1.0.8
 redis==5.0.1
 raven==6.10.0
-tc-aws==7.0.2
-tc-core==0.5
+thumbor-aws==0.9.1
 tc_redis==2.5.0
-thumbor[all]==7.7.7
+thumbor[all]==7.8.0
 thumbor-wand-engine==0.1.1


### PR DESCRIPTION
Minor fix to avoid legacy ENV format warning when deploying specifically on Metal servers. Does not affect runtime behaviour.